### PR TITLE
Generalise decoder

### DIFF
--- a/boutvecma/__init__.py
+++ b/boutvecma/__init__.py
@@ -1,4 +1,4 @@
 __all__ = ["decoder", "encoder"]
 
-from .decoder import BOUTDecoder
+from .decoder import BaseBOUTDecoder, SimpleBOUTDecoder
 from .encoder import BOUTEncoder

--- a/boutvecma/__init__.py
+++ b/boutvecma/__init__.py
@@ -1,4 +1,4 @@
 __all__ = ["decoder", "encoder"]
 
-from .decoder import BaseBOUTDecoder, SimpleBOUTDecoder
+from .decoder import BaseBOUTDecoder, SimpleBOUTDecoder, SampleLocationBOUTDecoder
 from .encoder import BOUTEncoder

--- a/boutvecma/decoder.py
+++ b/boutvecma/decoder.py
@@ -3,24 +3,33 @@ import os
 from easyvvuq.decoders import BaseDecoder
 from boutdata.data import BoutOptionsFile
 from xbout.load import open_boutdataset
+import inspect
+import re
 
 
-class BOUTDecoder(BaseDecoder, decoder_name="bout++"):
-    def __init__(self, target_dir=None, target_filename=None, variables=None):
+def flatten_dataframe_for_JSON(df):
+    """Flatten a pandas dataframe to a plain list, suitable for JSON serialisation"""
+    return df.values.flatten().tolist()
+
+
+class BaseBOUTDecoder(BaseDecoder, decoder_name="bout++-base"):
+    def __init_subclass__(cls):
+        super().__init_subclass__(cls.__name__)
+
+    def __init__(self, target_filename=None):
         """
         Parameters
         ==========
-        variables: iterable or None
-            Iterable of variables to collect from the output. If None, return everything
+        target_filename: str or None
+            Filename or glob to read in (default: "BOUT.dmp.*.nc")
         """
-        self.target_dir = target_dir or "data"
         self.target_filename = target_filename or "BOUT.dmp.*.nc"
-
-        # TODO: check it's an iterable or otherwise sensible type?
-        self.variables = variables
 
     @staticmethod
     def _get_output_path(run_info=None, outfile=None):
+        """
+        Get the path the run directory, and optionally the file outfile
+        """
         if run_info is None:
             raise RuntimeError("Passed 'None' to 'run_info'")
 
@@ -43,22 +52,57 @@ class BOUTDecoder(BaseDecoder, decoder_name="bout++"):
 
         return "run:finished" in settings_file
 
-    def parse_sim_output(self, run_info=None, *args, **kwargs):
+    def get_outputs(self, run_info):
+        """Read the BOUT++ outputs into an xarray dataframe"""
         data_files = self._get_output_path(run_info, self.target_filename)
-        df = open_boutdataset(data_files, info=False)
-
-        # For now, just return the variable itself
-        # TODO: add analysis step
-        return {
-            variable: df[variable][-1, ...].values.flatten().tolist()
-            for variable in self.variables
-        }
+        return open_boutdataset(data_files, info=False)
 
     def get_restart_dict(self):
+        """Serialise the class to a dict of JSON serialisable variables"""
+        # This is possibly too magic... get the variable names from
+        # the __init__ method
+        init_vars = inspect.signature(self.__init__).parameters.keys()
+        # Assuming that the __init__ does `self.var = var`, we can
+        # just return a dict of everything
+        try:
+            return {var: getattr(self, var) for var in init_vars}
+        except AttributeError as e:
+            # Let's try to give a helpful error message if this does go wrong
+            match = re.search(r"no attribute '(.*)'", str(e))
+            if match is None:
+                # Oops, something else
+                raise e
+            varname = match.group(1)
+            raise AttributeError(
+                f"'{varname}' doesn't seem to be a member of this instance.\nDid you miss 'self.{varname} = {varname}' in '__init__'?"
+            )
+
+    @staticmethod
+    def element_version():
+        return "0.1.0"
+
+
+class SimpleBOUTDecoder(BaseBOUTDecoder):
+    """Just collects individual variables at the last timestep"""
+
+    def __init__(self, target_filename=None, variables=None):
+        """
+        Parameters
+        ==========
+        variables: iterable or None
+            Iterable of variables to collect from the output. If None, return everything
+        """
+        super().__init__(target_filename=target_filename)
+
+        # TODO: check it's an iterable or otherwise sensible type?
+        self.variables = variables
+
+    def parse_sim_output(self, run_info=None, *args, **kwargs):
+        df = self.get_outputs(run_info)
+
         return {
-            "target_dir": self.target_dir,
-            "target_filename": self.target_filename,
-            "variables": self.variables,
+            variable: flatten_dataframe_for_JSON(df[variable][-1, ...])
+            for variable in self.variables
         }
 
     @staticmethod

--- a/boutvecma/test_decoder.py
+++ b/boutvecma/test_decoder.py
@@ -5,14 +5,14 @@ from boutdata.data import BoutOptions
 
 
 def test_decoder_create():
-    bout_decoder = decoder.BOUTDecoder()
+    bout_decoder = decoder.SimpleBOUTDecoder()
 
     assert isinstance(bout_decoder, BaseDecoder)
 
 
 def test_decoder_sim_complete(tmpdir):
 
-    bout_decoder = decoder.BOUTDecoder()
+    bout_decoder = decoder.SimpleBOUTDecoder()
     assert not bout_decoder.sim_complete({"run_dir": tmpdir})
 
     settings_file = BoutOptions()
@@ -29,7 +29,7 @@ def test_decoder_parse_sim_output_all_variables(tmpdir, monkeypatch):
 
     monkeypatch.setattr(decoder, "open_boutdataset", mock_open_boutdataset)
 
-    bout_decoder = decoder.BOUTDecoder()
+    bout_decoder = decoder.SimpleBOUTDecoder()
 
     data = bout_decoder.parse_sim_output({"run_dir": tmpdir})
 
@@ -44,7 +44,7 @@ def test_decoder_parse_sim_output_variable_list(tmpdir, monkeypatch):
 
     monkeypatch.setattr(decoder, "open_boutdataset", mock_open_boutdataset)
 
-    bout_decoder = decoder.BOUTDecoder(variables=["T"])
+    bout_decoder = decoder.SimpleBOUTDecoder(variables=["T"])
 
     data = bout_decoder.parse_sim_output({"run_dir": tmpdir})
 

--- a/example.py
+++ b/example.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 
 campaign = uq.Campaign(name="Conduction.")
 encoder = boutvecma.BOUTEncoder(template_input="models/conduction/data/BOUT.inp")
-decoder = boutvecma.BOUTDecoder(variables=["T"])
+decoder = boutvecma.SimpleBOUTDecoder(variables=["T"])
 params = {
     "conduction:chi": {"type": "float", "min": 0.0, "max": 1e3, "default": 1.0},
     "T:scale": {"type": "float", "min": 0.0, "max": 1e3, "default": 1.0},

--- a/example_sample_location.py
+++ b/example_sample_location.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+"""
+This example looks at time traces of temperature at two locations
+
+"""
+
+
+import boutvecma
+import easyvvuq as uq
+import chaospy
+import os
+import numpy as np
+import time
+import matplotlib.pyplot as plt
+
+campaign = uq.Campaign(name="Conduction.")
+encoder = boutvecma.BOUTEncoder(template_input="models/conduction/data/BOUT.inp")
+
+sample_locations = [
+    {"variable": "T", "output_name": "T_centre", "x": 0, "y": 50, "z": 0},
+    {"variable": "T", "output_name": "T_edge", "x": 0, "y": 10, "z": 0},
+]
+
+decoder = boutvecma.SampleLocationBOUTDecoder(sample_locations=sample_locations)
+params = {
+    "conduction:chi": {"type": "float", "min": 0.0, "max": 1e3, "default": 1.0},
+    "T:scale": {"type": "float", "min": 0.0, "max": 1e3, "default": 1.0},
+    "T:gauss_width": {"type": "float", "min": 0.0, "max": 1e3, "default": 0.2},
+    "T:gauss_centre": {"type": "float", "min": 0.0, "max": 2 * np.pi, "default": np.pi},
+}
+
+campaign.add_app("1D_conduction", params=params, encoder=encoder, decoder=decoder)
+
+vary = {
+    "T:scale": chaospy.Uniform(0.5, 1.5),
+    "T:gauss_centre": chaospy.Uniform(0.0, np.pi),
+}
+
+sampler = uq.sampling.PCESampler(vary=vary, polynomial_order=3)
+campaign.set_sampler(sampler)
+
+campaign.draw_samples()
+
+run_dirs = campaign.populate_runs_dir()
+
+print(f"Created run directories: {run_dirs}")
+
+time_start = time.time()
+campaign.apply_for_each_run_dir(
+    uq.actions.ExecuteLocal(
+        os.path.abspath("build/models/conduction/conduction -q -q -q -q -d .")
+    )
+)
+time_end = time.time()
+
+print(f"Finished, took {time_end - time_start}")
+
+campaign.collate()
+
+campaign.apply_analysis(
+    uq.analysis.PCEAnalysis(sampler=sampler, qoi_cols=["T_centre", "T_edge"])
+)
+
+results = campaign.get_last_analysis()
+
+state_filename = os.path.join(campaign.campaign_dir, "campaign_state.json")
+campaign.save_state(state_filename)
+
+plt.figure()
+results.plot_moments(
+    "T_centre",
+    xlabel=r"$\rho$",
+    filename=f"{campaign.campaign_dir}/T_centre_moments.png",
+)
+plt.figure()
+results.plot_sobols_first(
+    "T_centre",
+    xlabel=r"$\rho$",
+    filename=f"{campaign.campaign_dir}/T_centre_sobols_first.png",
+)
+plt.figure()
+results.plot_moments(
+    "T_edge", xlabel=r"$\rho$", filename=f"{campaign.campaign_dir}/T_edge_moments.png"
+)
+plt.figure()
+results.plot_sobols_first(
+    "T_edge",
+    xlabel=r"$\rho$",
+    filename=f"{campaign.campaign_dir}/T_edge_sobols_first.png",
+)


### PR DESCRIPTION
This uses some python magic like runtime reflection to try and do some of the boilerplate stuff.

@d7919 has suggested perhaps a much easier method: instead of running `./model -d .`, run `./model_with_analysis.sh`. This could then work with a much simpler decoder, perhaps even CSV